### PR TITLE
prompt: fix reverse-search, improve multiline commands support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ _testmain.go
 
 # Glide
 vendor/
+
+
+# Pytest
+.pytest_cache
+__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 ## Unreleased
 
 ### Added
+* Support for multi-line commands.
+* Support for tab characters in commands.
+* Integration tests.
+* Reverse search.
 
-* Reverse search
+### Fixed
+* Terminal failure after exiting.
 
 ## v0.2.3 (2018/10/25)
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,18 @@ generate: ## Run go generate
 build: ## Build example command lines.
 	./_example/build.sh
 
+.PHONY: build_app
+build_app: ## Build testing application.
+ifdef GO_RPOMPT_BUILD_PATH
+	@go build -o $(GO_RPOMPT_BUILD_PATH) ./internal/prompt_app/prompt_app.go
+else
+	@go build ./internal/prompt_app/prompt_app.go
+endif
+
+.PHONY: integration
+integration: ## Run integration tests.
+	@pytest -v ./test/integration
+
 .PHONY: help
 help: ## Show help text
 	@echo "Commands:"

--- a/buffer.go
+++ b/buffer.go
@@ -229,6 +229,34 @@ func (b *Buffer) SplitWideLines(maxWidth int) *Buffer {
 	return result
 }
 
+// ReplaceTabs replaces all `\t` characters with spaces.
+func (b *Buffer) ReplaceTabs(tabWidth int) *Buffer {
+	processedText := strings.Builder{}
+	runes := []rune(b.Text())
+	processedText.Grow(len(runes))
+
+	cmdCursor := b.cursorPosition
+	cursorDelta := 0
+
+	for cursor, r := range runes {
+		if r == rune('\t') {
+			for j := 0; j < tabWidth; j++ {
+				processedText.WriteByte(' ')
+			}
+			if cursor < cmdCursor {
+				cursorDelta += tabWidth - 1
+			}
+		} else {
+			processedText.WriteRune(r)
+		}
+	}
+
+	result := NewBuffer()
+	result.InsertText(processedText.String(), false, true)
+	result.setCursorPosition(cmdCursor + cursorDelta)
+	return result
+}
+
 // NewBuffer is constructor of Buffer struct.
 func NewBuffer() (b *Buffer) {
 	b = &Buffer{

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -227,3 +227,25 @@ func TestBuffer_SplitWideLines(t *testing.T) {
 	assert.Equal(t, "a\n\nb\n\nc\n", buf.Text())
 	assert.Equal(t, 2, buf.cursorPosition)
 }
+
+func TestBuffer_ReplaceTabs(t *testing.T) {
+	buf := NewBuffer()
+	buf.InsertText("строка1\n\tстрока2\n\tстрока 3", false, true)
+	buf.setCursorPosition(18) // 'с'
+	buf = buf.ReplaceTabs(4)
+	assert.Equal(t, "строка1\n    строка2\n    строка 3", buf.Text())
+	assert.Equal(t, 24, buf.cursorPosition)
+
+	buf = NewBuffer()
+	buf.InsertText("a\tb\tc\t", false, true)
+	buf.setCursorPosition(0)
+	buf = buf.ReplaceTabs(0)
+	assert.Equal(t, "abc", buf.Text())
+	assert.Equal(t, 0, buf.cursorPosition)
+
+	buf = NewBuffer()
+	buf.InsertText("localhost>\ta", false, true)
+	buf = buf.ReplaceTabs(4)
+	assert.Equal(t, "localhost>    a", buf.Text())
+	assert.Equal(t, 15, buf.cursorPosition)
+}

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -3,6 +3,8 @@ package prompt
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewBuffer(t *testing.T) {
@@ -195,4 +197,33 @@ func TestBuffer_SwapCharactersBeforeCursor(t *testing.T) {
 	if ac != ex {
 		t.Errorf("Should be %#v, got %#v", ex, ac)
 	}
+}
+
+func TestBuffer_SplitWideLines(t *testing.T) {
+	buf := NewBuffer()
+	buf.InsertText("зеленый \n красный \n синий \n белый", false, true)
+	buf.setCursorPosition(20) // `с`
+	buf = buf.SplitWideLines(3)
+	assert.Equal(t, "зел\nены\nй \n кр\nасн\nый \n си\nний\n \n бе\nлый", buf.Text())
+	assert.Equal(t, 24, buf.cursorPosition)
+
+	buf = NewBuffer()
+	buf.InsertText("long long line\nsecond line", false, true)
+	buf = buf.SplitWideLines(20)
+	assert.Equal(t, "long long line\nsecond line", buf.Text())
+	assert.Equal(t, 26, buf.cursorPosition)
+
+	buf = NewBuffer()
+	buf.InsertText("привет\nпока", false, true)
+	buf.setCursorPosition(2)
+	buf = buf.SplitWideLines(2)
+	assert.Equal(t, "пр\nив\nет\nпо\nка", buf.Text())
+	assert.Equal(t, 3, buf.cursorPosition)
+
+	buf = NewBuffer()
+	buf.InsertText("a\n\nb\n\nc\n", false, true)
+	buf.setCursorPosition(2)
+	buf = buf.SplitWideLines(1)
+	assert.Equal(t, "a\n\nb\n\nc\n", buf.Text())
+	assert.Equal(t, 2, buf.cursorPosition)
 }

--- a/history.go
+++ b/history.go
@@ -1,15 +1,10 @@
 package prompt
 
-import "strings"
-
 // History stores the texts that are entered.
 type History struct {
 	histories []string
 	tmp       []string
 	selected  int
-
-	lastReverseFinded  string
-	reverseSearchIndex int
 }
 
 // Add to add text in history.
@@ -54,25 +49,6 @@ func (h *History) Newer(buf *Buffer) (new *Buffer, changed bool) {
 	new = NewBuffer()
 	new.InsertText(h.tmp[h.selected], false, true)
 	return new, true
-}
-
-func (h *History) reverseFindInHistory(input string) bool {
-	if input == "" {
-		h.lastReverseFinded = ""
-		return true
-	}
-
-	history := h.histories[:len(h.histories)-h.reverseSearchIndex]
-	historyLen := len(history)
-
-	for i, _ := range history {
-		if strings.Contains(history[historyLen-i-1], input) {
-			h.lastReverseFinded = history[historyLen-i-1]
-			return true
-		}
-	}
-
-	return false
 }
 
 // NewHistory returns new history object.

--- a/history.go
+++ b/history.go
@@ -1,5 +1,7 @@
 package prompt
 
+import "strings"
+
 // History stores the texts that are entered.
 type History struct {
 	histories []string
@@ -54,6 +56,17 @@ func (h *History) Newer(buf *Buffer) (new *Buffer, changed bool) {
 // SetCurrentCmd sets current command.
 func (h *History) SetCurrentCmd(cmd string) {
 	h.tmp[h.selected] = cmd
+}
+
+// FindMatch finds last match of input in the specified prefix
+// in current history state.
+func (h *History) FindMatch(input string, prefix int) int {
+	for i := prefix; i >= 0; i-- {
+		if strings.Contains(h.tmp[i], input) {
+			return i
+		}
+	}
+	return -1
 }
 
 // NewHistory returns new history object.

--- a/history.go
+++ b/history.go
@@ -51,6 +51,11 @@ func (h *History) Newer(buf *Buffer) (new *Buffer, changed bool) {
 	return new, true
 }
 
+// SetCurrentCmd sets current command.
+func (h *History) SetCurrentCmd(cmd string) {
+	h.tmp[h.selected] = cmd
+}
+
 // NewHistory returns new history object.
 func NewHistory() *History {
 	return &History{

--- a/history_test.go
+++ b/history_test.go
@@ -3,6 +3,8 @@ package prompt
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHistoryClear(t *testing.T) {
@@ -59,4 +61,15 @@ func TestHistoryOlder(t *testing.T) {
 	if !reflect.DeepEqual("echo 1", buf2.Text()) {
 		t.Errorf("Should be %#v, but got %#v", "echo 1", buf2.Text())
 	}
+}
+
+func TestHistorySetCurrent(t *testing.T) {
+	history := NewHistory()
+	history.Add("entry0")
+	history.Add("entry1")
+	history.Add("entry2")
+
+	newCmd := "alternative"
+	history.SetCurrentCmd(newCmd)
+	assert.Equal(t, newCmd, history.tmp[history.selected])
 }

--- a/history_test.go
+++ b/history_test.go
@@ -73,3 +73,20 @@ func TestHistorySetCurrent(t *testing.T) {
 	history.SetCurrentCmd(newCmd)
 	assert.Equal(t, newCmd, history.tmp[history.selected])
 }
+
+func TestHistoryFindMatch(t *testing.T) {
+	history := NewHistory()
+	history.Add("line 0")
+	history.Add("cmd1")
+	history.Add("cmd2")
+	history.Add("")
+	history.Add("x")
+	history.SetCurrentCmd("echo")
+
+	assert.Equal(t, 5, history.FindMatch("", 5))
+	assert.Equal(t, 5, history.FindMatch("c", 5))
+	assert.Equal(t, 2, history.FindMatch("cmd", 2))
+	assert.Equal(t, 1, history.FindMatch("cmd1", 2))
+	assert.Equal(t, 0, history.FindMatch("line", 5))
+	assert.Equal(t, -1, history.FindMatch("line 10", 5))
+}

--- a/internal/prompt_app/prompt_app.go
+++ b/internal/prompt_app/prompt_app.go
@@ -1,0 +1,124 @@
+// Example application to run integration tests.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/c-bata/go-prompt"
+)
+
+// Console describes the console.
+type Console struct {
+	title             string
+	input             string
+	prefix            string
+	livePrefix        string
+	livePrefixFunc    func() (string, bool)
+	livePrefixEnabled bool
+	prompt            *prompt.Prompt
+}
+
+// NewConsole creates a new Console instance.
+func NewConsole() *Console {
+	console := Console{}
+	console.title = "prompt_app"
+	console.prefix = "prompt_app> "
+	console.livePrefix = "> "
+	console.livePrefixFunc = func() (string, bool) {
+		return console.livePrefix, console.livePrefixEnabled
+	}
+	console.prompt = prompt.New(getExecutor(&console),
+		completer, getPromptOptions(&console)...)
+	return &console
+}
+
+// addStmt merges two commands.
+// for multi-lines commands use `#` at the beginning and at the end of the command.
+func addStmt(have string, input string) (string, bool) {
+	isInputFinish := len(input) > 0 && input[len(input)-1] == '#'
+	if len(have) == 0 {
+		if len(input) > 0 {
+			return input, input[0] != '#'
+		}
+		return input, true
+	}
+	isMultiline := have[0] == '#'
+	isCompleted := isInputFinish
+	return have + "\n" + input, !isMultiline || isCompleted
+}
+
+// getExecutor creates an executor.
+func getExecutor(console *Console) prompt.Executor {
+	return func(in string) {
+		if in == "exit" {
+			fmt.Println()
+			os.Exit(0)
+		}
+		var completed bool
+		console.input, completed = addStmt(console.input, in)
+		if !completed {
+			console.livePrefixEnabled = true
+			return
+		}
+		fmt.Printf("cmd: %s\n", console.input)
+		console.prompt.PushToHistory(console.input)
+		console.input = ""
+		console.livePrefixEnabled = false
+	}
+}
+
+// getPromptOptions returns prompt options.
+func getPromptOptions(console *Console) []prompt.Option {
+	options := []prompt.Option{
+		prompt.OptionTitle(console.title),
+		prompt.OptionPrefix(console.prefix),
+		prompt.OptionLivePrefix(console.livePrefixFunc),
+
+		prompt.OptionSuggestionBGColor(prompt.DarkGray),
+		prompt.OptionPreviewSuggestionTextColor(prompt.DefaultColor),
+
+		prompt.OptionDisableAutoHistory(),
+		prompt.OptionReverseSearch(),
+	}
+	args := os.Args
+	if len(args) > 1 {
+		histories := strings.Split(args[1], ";")
+		options = append(options, prompt.OptionHistory(histories))
+	}
+	if len(args) > 2 {
+		socketUri := args[2]
+		options = append(options, prompt.OptionEnableRenderSubscribeMode(socketUri))
+	}
+	return options
+}
+
+// completer is function used for completion in the prompt.
+func completer(d prompt.Document) []prompt.Suggest {
+	if len(d.Text) == 0 {
+		return []prompt.Suggest{}
+	}
+	words := []string{
+		"abc",
+		"aad",
+		"aba",
+		"aart",
+		"apple",
+		"git",
+		"gggit",
+		"gist",
+	}
+	result := make([]prompt.Suggest, 0)
+	for _, word := range words {
+		if strings.HasPrefix(word, d.Text) {
+			result = append(result, prompt.Suggest{Text: word})
+		}
+	}
+	return result
+}
+
+func main() {
+	console := NewConsole()
+	console.prompt.Run()
+}

--- a/key_bind_func.go
+++ b/key_bind_func.go
@@ -27,13 +27,31 @@ func DeleteBeforeChar(buf *Buffer) {
 	buf.DeleteBeforeCursor(1)
 }
 
-// GoRightChar Forward one character
+// GoRightChar forwards to one character to the right.
+// In the case of a multi-line command the cursor moves down,
+// when the end of the line is reached.
 func GoRightChar(buf *Buffer) {
+	if buf.Document().GetCursorRightPosition(1) == 0 {
+		if !buf.Document().OnLastLine() {
+			buf.CursorDown(1)
+			GoLineBeginning(buf)
+		}
+		return
+	}
 	buf.CursorRight(1)
 }
 
-// GoLeftChar Backward one character
+// GoLeftChar backward to one character to the left.
+// In the case of a multi-line command the cursor moves up,
+// when the begin of the line is reached.
 func GoLeftChar(buf *Buffer) {
+	if buf.Document().GetCursorLeftPosition(1) == 0 {
+		if buf.Document().CursorPositionRow() != 0 {
+			buf.CursorUp(1)
+			GoLineEnd(buf)
+		}
+		return
+	}
 	buf.CursorLeft(1)
 }
 

--- a/key_bind_func_test.go
+++ b/key_bind_func_test.go
@@ -1,0 +1,43 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoRightChar(t *testing.T) {
+	input := "зеленый\nred\nсиний"
+
+	buf := NewBuffer()
+	buf.InsertText(input, false, true)
+
+	GoRightChar(buf)
+	assert.Equal(t, len([]rune(input)), buf.cursorPosition)
+
+	buf.setCursorPosition(0)
+	GoRightChar(buf)
+	assert.Equal(t, 1, buf.cursorPosition)
+
+	buf.setCursorPosition(6)
+	GoRightChar(buf)
+	assert.Equal(t, 7, buf.cursorPosition)
+}
+
+func TestGoLeftChar(t *testing.T) {
+	input := "зеленый\nred\nсиний"
+
+	buf := NewBuffer()
+	buf.InsertText(input, false, true)
+
+	GoLeftChar(buf)
+	assert.Equal(t, len([]rune(input))-1, buf.cursorPosition)
+
+	buf.setCursorPosition(0)
+	GoLeftChar(buf)
+	assert.Equal(t, 0, buf.cursorPosition)
+
+	buf.setCursorPosition(8)
+	GoLeftChar(buf)
+	assert.Equal(t, 7, buf.cursorPosition)
+}

--- a/option.go
+++ b/option.go
@@ -24,7 +24,7 @@ func OptionWriter(x ConsoleWriter) Option {
 // OptionTitle to set title displayed at the header bar of terminal.
 func OptionTitle(x string) Option {
 	return func(p *Prompt) error {
-		p.renderer.title = x
+		p.title = x
 		return nil
 	}
 }
@@ -32,7 +32,7 @@ func OptionTitle(x string) Option {
 // OptionPrefix to set prefix string.
 func OptionPrefix(x string) Option {
 	return func(p *Prompt) error {
-		p.renderer.prefix = x
+		p.prefix = x
 		return nil
 	}
 }
@@ -56,7 +56,7 @@ func OptionCompletionWordSeparator(x string) Option {
 // OptionLivePrefix to change the prefix dynamically by callback function
 func OptionLivePrefix(f func() (prefix string, useLivePrefix bool)) Option {
 	return func(p *Prompt) error {
-		p.renderer.livePrefixCallback = f
+		p.livePrefixCallback = f
 		return nil
 	}
 }
@@ -272,11 +272,11 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	registerConsoleWriter(defaultWriter)
 
 	pt := &Prompt{
-		in: NewStandardInputParser(),
+		prefix:             "> ",
+		in:                 NewStandardInputParser(),
+		livePrefixCallback: func() (string, bool) { return "", false },
 		renderer: &Render{
-			prefix:                       "> ",
 			out:                          defaultWriter,
-			livePrefixCallback:           func() (string, bool) { return "", false },
 			prefixTextColor:              Blue,
 			prefixBGColor:                DefaultColor,
 			inputTextColor:               DefaultColor,

--- a/option.go
+++ b/option.go
@@ -266,6 +266,17 @@ func OptionSetExitCheckerOnInput(fn ExitChecker) Option {
 	}
 }
 
+// OptionReverseSearch enables reverse search option.
+func OptionReverseSearch() Option {
+	return func(p *Prompt) error {
+		p.isReverseSearchEnabled = true
+		return nil
+	}
+}
+
+// getInputParser returns input parser.
+var getInputParser = NewStandardInputParser
+
 // New returns a Prompt with powerful auto-completion.
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	defaultWriter := NewStdoutWriter()
@@ -273,7 +284,7 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 
 	pt := &Prompt{
 		prefix:             "> ",
-		in:                 NewStandardInputParser(),
+		in:                 getInputParser(),
 		livePrefixCallback: func() (string, bool) { return "", false },
 		renderer: &Render{
 			out:                          defaultWriter,

--- a/option.go
+++ b/option.go
@@ -1,5 +1,9 @@
 package prompt
 
+const (
+	defaultTabWidth = 4
+)
+
 // Option is the type to replace default parameters.
 // prompt.New accepts any number of options (this is functional option pattern).
 type Option func(prompt *Prompt) error
@@ -200,7 +204,14 @@ func OptionMaxSuggestion(x uint16) Option {
 // OptionHistory to set history expressed by string array.
 func OptionHistory(x []string) Option {
 	return func(p *Prompt) error {
-		p.history.histories = x
+		histories := make([]string, 0, len(x))
+		for _, history := range x {
+			historyBuf := NewBuffer()
+			historyBuf.InsertText(history, false, true)
+			historyBuf = historyBuf.ReplaceTabs(defaultTabWidth)
+			histories = append(histories, historyBuf.Text())
+		}
+		p.history.histories = histories
 		p.history.Clear()
 		return nil
 	}

--- a/option.go
+++ b/option.go
@@ -274,6 +274,14 @@ func OptionReverseSearch() Option {
 	}
 }
 
+// OptionDisableAutoHistory disables auto pushes to the history.
+func OptionDisableAutoHistory() Option {
+	return func(p *Prompt) error {
+		p.isAutoHistoryEnabled = false
+		return nil
+	}
+}
+
 // getInputParser returns input parser.
 var getInputParser = NewStandardInputParser
 
@@ -283,9 +291,10 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	registerConsoleWriter(defaultWriter)
 
 	pt := &Prompt{
-		prefix:             "> ",
-		in:                 getInputParser(),
-		livePrefixCallback: func() (string, bool) { return "", false },
+		prefix:               "> ",
+		in:                   getInputParser(),
+		livePrefixCallback:   func() (string, bool) { return "", false },
+		isAutoHistoryEnabled: true,
 		renderer: &Render{
 			out:                          defaultWriter,
 			prefixTextColor:              Blue,

--- a/option.go
+++ b/option.go
@@ -1,5 +1,7 @@
 package prompt
 
+import "net"
+
 const (
 	defaultTabWidth = 4
 )
@@ -290,6 +292,15 @@ func OptionDisableAutoHistory() Option {
 	return func(p *Prompt) error {
 		p.isAutoHistoryEnabled = false
 		return nil
+	}
+}
+
+// OptionEnableRenderSubscribeMode enables a subscription to rendering updates.
+func OptionEnableRenderSubscribeMode(socketUri string) Option {
+	return func(prompt *Prompt) error {
+		var err error
+		prompt.notifyConn, err = net.Dial("unix", socketUri)
+		return err
 	}
 }
 

--- a/prompt.go
+++ b/prompt.go
@@ -32,6 +32,7 @@ type location struct {
 type renderCtx struct {
 	cmd              *Buffer
 	cursor           location
+	endCursor        location
 	completion       *CompletionManager
 	prefixColor      Color
 	prefix           string
@@ -47,6 +48,7 @@ func (prompt *Prompt) fillCtx(renderEvent int) renderCtx {
 	ctx := renderCtx{
 		cmd:         cmd,
 		cursor:      prompt.cursor,
+		endCursor:   prompt.endCursor,
 		completion:  prompt.completion,
 		prefixColor: prompt.renderer.prefixTextColor,
 		prefix:      prefix,
@@ -62,6 +64,7 @@ type Prompt struct {
 	in                ConsoleParser
 	buf               *Buffer
 	cursor            location
+	endCursor         location
 	renderer          *Render
 	executor          Executor
 	history           *History
@@ -160,7 +163,7 @@ func (p *Prompt) Run() {
 		case w := <-winSizeCh:
 			p.onInputUpdate()
 			p.renderer.UpdateWinSize(w)
-			p.render(basicRenderEvent)
+			p.render(windowResizeRenderEvent)
 		case code := <-exitCh:
 			p.onInputUpdate()
 			p.render(breakLineRenderEvent)
@@ -427,7 +430,7 @@ func (prompt *Prompt) onInputUpdate() {
 // updates current cursor position.
 func (prompt *Prompt) render(event int) {
 	ctx := prompt.fillCtx(event)
-	prompt.cursor.row, prompt.cursor.col = prompt.renderer.Render(ctx)
+	prompt.cursor, prompt.endCursor = prompt.renderer.Render(ctx)
 }
 
 // inReverseSearchMode returns true if the prompt is in reverse-search mode.

--- a/prompt.go
+++ b/prompt.go
@@ -418,6 +418,7 @@ func (prompt *Prompt) getCurrentPrefix() string {
 
 // onInputUpdate does necessary actions at the input update moment.
 func (prompt *Prompt) onInputUpdate() {
+	prompt.buf = prompt.buf.ReplaceTabs(defaultTabWidth)
 	if prompt.inReverseSearchMode() {
 		prompt.reverseSearch.update(prompt.buf.Text())
 		return
@@ -469,12 +470,21 @@ func (p *Prompt) disableReverseSearch() {
 	p.reverseSearch = nil
 }
 
+// pushToHistory takes command, replaces tabs with spaces,
+// pushes it to the history.
+func (p *Prompt) pushToHistory(cmd string) {
+	cmdBuf := NewBuffer()
+	cmdBuf.InsertText(cmd, false, true)
+	cmdBuf = cmdBuf.ReplaceTabs(defaultTabWidth)
+	p.history.Add(cmdBuf.Text())
+}
+
 // PushToHistory pushes to the history, if auto history is disabled.
 func (p *Prompt) PushToHistory(cmd string) error {
 	if p.isAutoHistoryEnabled {
 		return fmt.Errorf("external pushes to the history are forbidden, " +
 			"use `OptionDisableAutoHistory`")
 	}
-	p.history.Add(cmd)
+	p.pushToHistory(cmd)
 	return nil
 }

--- a/prompt.go
+++ b/prompt.go
@@ -41,15 +41,19 @@ type renderCtx struct {
 
 // fillCtx fills render context.
 func (prompt *Prompt) fillCtx(renderEvent int) renderCtx {
-	ctx := renderCtx{}
-	ctx.cmd, _ = prompt.getCmdToRender()
-	ctx.prefix = prompt.getCurrentPrefix()
-	ctx.prefixColor = prompt.renderer.prefixTextColor
-	ctx.cursor = prompt.cursor
-	ctx.completion = prompt.completion
-	ctx.renderCompletion = !prompt.inReverseSearchMode() &&
-		!(prompt.buf.NewLineCount() > 0)
-	ctx.renderEvent = renderEvent
+	cmd, _ := prompt.getCmdToRender()
+	prefix := prompt.getCurrentPrefix()
+
+	ctx := renderCtx{
+		cmd:         cmd,
+		cursor:      prompt.cursor,
+		completion:  prompt.completion,
+		prefixColor: prompt.renderer.prefixTextColor,
+		prefix:      prefix,
+		renderCompletion: !prompt.inReverseSearchMode() &&
+			!(prompt.buf.NewLineCount() > 0),
+		renderEvent: renderEvent,
+	}
 	return ctx
 }
 

--- a/prompt.go
+++ b/prompt.go
@@ -79,6 +79,9 @@ type Prompt struct {
 
 	// isReverseSearchEnabled is true if such option was provided.
 	isReverseSearchEnabled bool
+
+	// isAutoHistoryEnabled is true if automatic writing to the history is enabled.
+	isAutoHistoryEnabled bool
 }
 
 // Exec is the struct contains user input context.
@@ -187,7 +190,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		p.render(breakLineRenderEvent)
 		p.buf = NewBuffer()
 		exec = &Exec{input: execCmd}
-		if exec.input != "" {
+		if exec.input != "" && p.isAutoHistoryEnabled {
 			p.history.Add(exec.input)
 		}
 	case ControlC:
@@ -457,4 +460,14 @@ func (p *Prompt) disableReverseSearch() {
 	}
 
 	p.reverseSearch = nil
+}
+
+// PushToHistory pushes to the history, if auto history is disabled.
+func (p *Prompt) PushToHistory(cmd string) error {
+	if p.isAutoHistoryEnabled {
+		return fmt.Errorf("external pushes to the history are forbidden, " +
+			"use `OptionDisableAutoHistory`")
+	}
+	p.history.Add(cmd)
+	return nil
 }

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -1,0 +1,57 @@
+package prompt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCurrentPrefix(t *testing.T) {
+	prompt := &Prompt{
+		prefix: "prefix",
+		livePrefixCallback: func() (prefix string, useLivePrefix bool) {
+			return "", false
+		},
+		history: NewHistory(),
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		actualPrefix := prompt.getCurrentPrefix()
+		assert.Equal(t, prompt.prefix, actualPrefix)
+	})
+
+	t.Run("live-prefix", func(t *testing.T) {
+		prompt.livePrefixCallback = func() (prefix string, useLivePrefix bool) {
+			return "live_prefix", true
+		}
+		actualPrefix := prompt.getCurrentPrefix()
+		assert.Equal(t, "live_prefix", actualPrefix)
+	})
+
+}
+
+func TestGetCmdToRender(t *testing.T) {
+	prompt := &Prompt{
+		prefix: "prefix> ",
+		livePrefixCallback: func() (prefix string, useLivePrefix bool) {
+			return "", false
+		},
+		history: NewHistory(),
+	}
+
+	input := "Ïа_#строка"
+	prompt.buf = NewBuffer()
+	prompt.buf.InsertText(input, false, true)
+
+	matchedCmd := fmt.Sprintf("print(`%s`)", input)
+	prompt.history.Add(matchedCmd)
+
+	t.Run("basic", func(t *testing.T) {
+		cmdBuf, prefixLen := prompt.getCmdToRender()
+		assert.Equal(t, "prefix> "+input, cmdBuf.Text())
+		assert.Equal(t, 8, prefixLen)
+		assert.Equal(t, 8+len([]rune(input)), cmdBuf.cursorPosition)
+	})
+
+}

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -165,3 +165,13 @@ func TestPushToHistory(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestInternalPushToHistory(t *testing.T) {
+	prompt := Prompt{history: NewHistory()}
+	cmd := "if something then\n\tprint(1)\nelse\n\tprint(2)"
+	prompt.pushToHistory(cmd)
+
+	assert.Equal(t, 1, len(prompt.history.histories))
+	assert.Equal(t, "if something then\n    print(1)\nelse\n    print(2)",
+		prompt.history.histories[0])
+}

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -135,3 +135,33 @@ func TestDisableReverseSearch(t *testing.T) {
 	assert.Equal(t, "", prompt.buf.Text())
 	assert.Equal(t, len(history.tmp)-1, history.selected)
 }
+
+func TestPushToHistory(t *testing.T) {
+	oldGetInputParser := getInputParser
+	defer func() {
+		getInputParser = oldGetInputParser
+	}()
+	getInputParser = func() *PosixParser {
+		return nil
+	}
+
+	t.Run("option enabled", func(t *testing.T) {
+		prompt := New(
+			func(s string) {},
+			func(d Document) []Suggest { return []Suggest{} },
+			OptionDisableAutoHistory(),
+		)
+		err := prompt.PushToHistory("cmd")
+		assert.NoError(t, err)
+		assert.Equal(t, len(prompt.history.histories), 1)
+	})
+
+	t.Run("option disabled", func(t *testing.T) {
+		prompt := New(
+			func(s string) {},
+			func(d Document) []Suggest { return []Suggest{} },
+		)
+		err := prompt.PushToHistory("cmd")
+		assert.Error(t, err)
+	})
+}

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -29,6 +29,15 @@ func TestGetCurrentPrefix(t *testing.T) {
 		assert.Equal(t, "live_prefix", actualPrefix)
 	})
 
+	t.Run("reverse-search enabled", func(t *testing.T) {
+		prompt.reverseSearch = NewReverseSearch(prompt.history)
+		prompt.reverseSearch.matchedIndex = 1
+		prompt.buf = NewBuffer()
+		prompt.buf.InsertText("input", false, true)
+		actualPrefix := prompt.getCurrentPrefix()
+		assert.Equal(t, fmt.Sprintf(matchSearchPrefixFmt, "input"),
+			actualPrefix)
+	})
 }
 
 func TestGetCmdToRender(t *testing.T) {
@@ -54,4 +63,75 @@ func TestGetCmdToRender(t *testing.T) {
 		assert.Equal(t, 8+len([]rune(input)), cmdBuf.cursorPosition)
 	})
 
+	t.Run("reverse-search enabled", func(t *testing.T) {
+		prompt.reverseSearch = NewReverseSearch(prompt.history)
+		prompt.reverseSearch.update(input)
+
+		cmdBuf, prefixLen := prompt.getCmdToRender()
+		expectedPrefx := fmt.Sprintf(matchSearchPrefixFmt, input)
+		assert.Equal(t, expectedPrefx+matchedCmd, cmdBuf.Text())
+		assert.Equal(t, len(expectedPrefx), prefixLen)
+		assert.Equal(t, len([]rune(matchedCmd))+len([]rune(expectedPrefx)), cmdBuf.cursorPosition)
+	})
+}
+
+func TestInReverseSearchMode(t *testing.T) {
+	prompt := &Prompt{history: NewHistory()}
+	assert.False(t, prompt.inReverseSearchMode())
+	prompt.reverseSearch = NewReverseSearch(prompt.history)
+	assert.True(t, prompt.inReverseSearchMode())
+	prompt.reverseSearch = nil
+	assert.False(t, prompt.inReverseSearchMode())
+}
+
+func TestEnableReverseSearch(t *testing.T) {
+	prompt := &Prompt{
+		isReverseSearchEnabled: true,
+		history:                NewHistory(),
+		buf:                    NewBuffer(),
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		prompt.buf.InsertText("multi\nline", false, true)
+		prompt.enableReverseSearch()
+		assert.Equal(t, "", prompt.buf.Text())
+		assert.NotNil(t, prompt.reverseSearch)
+		prompt.reverseSearch = nil
+	})
+
+	t.Run("disabled option", func(t *testing.T) {
+		prompt.buf.InsertText("multi\nline", false, true)
+		prompt.isReverseSearchEnabled = false
+		prompt.enableReverseSearch()
+		assert.Nil(t, prompt.reverseSearch)
+		assert.Equal(t, "multi\nline", prompt.buf.Text())
+	})
+}
+
+func TestDisableReverseSearch(t *testing.T) {
+	history := NewHistory()
+	history.Add("entry 11")
+	history.Add("entry 2")
+
+	prompt := &Prompt{
+		isReverseSearchEnabled: true,
+		history:                history,
+		reverseSearch:          NewReverseSearch(history),
+		buf:                    NewBuffer(),
+	}
+
+	// Have match.
+	prompt.reverseSearch.update("entry 1")
+	prompt.disableReverseSearch()
+	assert.Nil(t, prompt.reverseSearch)
+	assert.Equal(t, "entry 11", prompt.buf.Text())
+	assert.Equal(t, 0, history.selected)
+
+	// Haven't match.
+	prompt.reverseSearch = NewReverseSearch(history)
+	prompt.reverseSearch.update("eentry")
+	prompt.disableReverseSearch()
+	assert.Nil(t, prompt.reverseSearch)
+	assert.Equal(t, "", prompt.buf.Text())
+	assert.Equal(t, len(history.tmp)-1, history.selected)
 }

--- a/render.go
+++ b/render.go
@@ -12,6 +12,7 @@ const (
 	basicRenderEvent = iota
 	// breakLineRenderEvent renders context with break-line.
 	breakLineRenderEvent
+	windowResizeRenderEvent
 )
 
 // Render to render prompt information from state of Buffer.
@@ -182,8 +183,9 @@ func (r *Render) preprocessCtx(ctx renderCtx) renderCtx {
 	return ctx
 }
 
-// renderCtx renders context to the out, returns new position of the cursor.
-func (r *Render) renderCtx(ctx renderCtx) (int, int) {
+// renderCtx renders context to the out, returns
+// (new location of cursor, new location of the end of the rendered command).
+func (r *Render) renderCtx(ctx renderCtx) (newCursor location, newEndCursor location) {
 	// Preprocess the context.
 	ctx = r.preprocessCtx(ctx)
 
@@ -194,8 +196,17 @@ func (r *Render) renderCtx(ctx renderCtx) (int, int) {
 		len([]rune(ctx.cmd.Text())),
 	)
 
-	// Erase rendered recently.
-	r.clear(ctx.cursor.row*int(r.col) + ctx.cursor.col)
+	ctxCursorPos := ctx.cursor.row*int(r.col) + ctx.cursor.col
+	ctxEndCursorPos := ctx.endCursor.row*int(r.col) + ctx.endCursor.col
+
+	if ctx.renderEvent == windowResizeRenderEvent {
+		r.clear(ctxCursorPos, true)
+	} else {
+		// Move to the end of rendered recently.
+		r.move(ctxCursorPos, ctxEndCursorPos)
+		// Erase rendered recently.
+		r.clear(ctxEndCursorPos, false)
+	}
 
 	// Render.
 	writeCmdWithPrefix(r.out, ctx.cmd.Text(), len(ctx.prefix),
@@ -205,20 +216,20 @@ func (r *Render) renderCtx(ctx renderCtx) (int, int) {
 	// Move cursor back to the position inside cmd.
 	r.move(endRow*int(r.col)+endCol, cursorRow*int(r.col)+cursorCol)
 
-	return cursorRow, cursorCol
+	return location{cursorRow, cursorCol}, location{endRow, endCol}
 }
 
 // Render is main render function.
 // It calls suitable sub-render function (as `renderBreakLine`) in dependence of render event.
 // Returns new cursor position.
-func (r *Render) Render(ctx renderCtx) (int, int) {
+func (r *Render) Render(ctx renderCtx) (location, location) {
 	// In situations where a pseudo tty is allocated (e.g. within a docker container),
 	// window size via TIOCGWINSZ is not immediately available and will result in 0,0 dimensions.
 	if ctx.renderEvent == breakLineRenderEvent {
 		return r.renderBreakLine(ctx)
 	}
 	if r.col == 0 {
-		return 0, 0
+		return location{}, location{}
 	}
 	defer func() { debug.AssertNoError(r.out.Flush()) }()
 
@@ -229,12 +240,12 @@ func (r *Render) Render(ctx renderCtx) (int, int) {
 	}()
 
 	// Render current state.
-	cursorRow, cursorCol := r.renderCtx(ctx)
+	curCursor, endCursor := r.renderCtx(ctx)
 
 	if ctx.renderCompletion {
 		r.renderCompletion(ctx)
 		if suggest, ok := ctx.completion.GetSelectedSuggestion(); ok {
-			cursorCol = r.backward(cursorCol, runewidth.StringWidth(
+			curCursor.col = r.backward(curCursor.col, runewidth.StringWidth(
 				ctx.cmd.Document().GetWordBeforeCursorUntilSeparator(
 					ctx.completion.wordSeparator,
 				),
@@ -243,22 +254,22 @@ func (r *Render) Render(ctx renderCtx) (int, int) {
 			r.out.SetColor(r.previewSuggestionTextColor, r.previewSuggestionBGColor, false)
 			r.out.WriteStr(suggest.Text)
 			r.out.SetColor(DefaultColor, DefaultColor, false)
-			cursorCol += runewidth.StringWidth(suggest.Text)
+			curCursor.col += runewidth.StringWidth(suggest.Text)
 
 			rest := ctx.cmd.Document().TextAfterCursor()
 			r.out.WriteStr(rest)
-			cursorCol += runewidth.StringWidth(rest)
-			r.lineWrap(cursorCol)
+			curCursor.col += runewidth.StringWidth(rest)
+			r.lineWrap(curCursor.col)
 
-			cursorCol = r.backward(cursorCol, runewidth.StringWidth(rest))
+			curCursor.col = r.backward(curCursor.col, runewidth.StringWidth(rest))
 		}
 	}
 
-	return cursorRow, cursorCol
+	return curCursor, endCursor
 }
 
 // renderBreakline renders state with linebreak and calls breakline callback.
-func (r *Render) renderBreakLine(ctx renderCtx) (int, int) {
+func (r *Render) renderBreakLine(ctx renderCtx) (location, location) {
 	defer func() { debug.AssertNoError(r.out.Flush()) }()
 
 	// Hide cursor to prevent blinking.
@@ -280,14 +291,31 @@ func (r *Render) renderBreakLine(ctx renderCtx) (int, int) {
 		r.breakLineCallback(cmdDocument)
 	}
 
-	return 0, 0
+	return location{}, location{}
 }
 
 // clear erases the screen from a beginning of input
-// even if there is line break which means input length exceeds a window's width.
-func (r *Render) clear(cursor int) {
-	r.move(cursor, 0)
+//
+// function supports two work modes.
+// `hard=true` when `EraseDown` is used for clearing the rendered text.
+//
+// `hard=false`, when softly clear line by line is used.
+//
+// `EraseDown` may cause flickering in some terminals (e.g. `urxvt`).
+func (r *Render) clear(cursor int, hard bool) {
 	r.out.EraseDown()
+	if !hard {
+		fromX, fromY := r.toPos(cursor)
+		r.out.CursorBackward(fromX)
+		for i := 0; i < fromY; i++ {
+			r.out.EraseEndOfLine()
+			r.out.CursorUp(1)
+		}
+		r.out.EraseEndOfLine()
+	} else {
+		r.move(cursor, 0)
+		r.out.EraseDown()
+	}
 }
 
 // backward moves cursor to backward from a current cursor position

--- a/render.go
+++ b/render.go
@@ -176,8 +176,17 @@ func writeCmdWithPrefix(
 	out.WriteStr(cmd[prefixLen:])
 }
 
+// preprocessCtx preprocesses the context before rendering.
+func (r *Render) preprocessCtx(ctx renderCtx) renderCtx {
+	ctx.cmd = ctx.cmd.SplitWideLines(int(r.col))
+	return ctx
+}
+
 // renderCtx renders context to the out, returns new position of the cursor.
 func (r *Render) renderCtx(ctx renderCtx) (int, int) {
+	// Preprocess the context.
+	ctx = r.preprocessCtx(ctx)
+
 	// Calculate current cursor position.
 	cursorRow, cursorCol := ctx.cmd.Document().GetCursorPosition()
 	// Calculate cursor position of the line end.
@@ -195,6 +204,7 @@ func (r *Render) renderCtx(ctx renderCtx) (int, int) {
 
 	// Move cursor back to the position inside cmd.
 	r.move(endRow*int(r.col)+endCol, cursorRow*int(r.col)+cursorCol)
+
 	return cursorRow, cursorCol
 }
 
@@ -247,7 +257,7 @@ func (r *Render) Render(ctx renderCtx) (int, int) {
 	return cursorRow, cursorCol
 }
 
-// renderBreakline renders state with linebreak and calls break-line callback.
+// renderBreakline renders state with linebreak and calls breakline callback.
 func (r *Render) renderBreakLine(ctx renderCtx) (int, int) {
 	defer func() { debug.AssertNoError(r.out.Flush()) }()
 
@@ -269,6 +279,7 @@ func (r *Render) renderBreakLine(ctx renderCtx) (int, int) {
 	if r.breakLineCallback != nil {
 		r.breakLineCallback(cmdDocument)
 	}
+
 	return 0, 0
 }
 

--- a/reverse_search.go
+++ b/reverse_search.go
@@ -1,0 +1,54 @@
+package prompt
+
+import (
+	"strings"
+)
+
+const (
+	matchSearchPrefixFmt = "(reverse-i-search)`%s':"
+	failSearchPrefixFmt  = "(failed reverse-i-search)`%s':"
+)
+
+// reverseSearchState contains info about reverseSearch state.
+type reverseSearchState struct {
+	// history, with which reverse-search works.
+	history *History
+	// searchFromIndex is the last history index, included to the search scope.
+	searchFromIndex int
+	// matchedIndex is the index of the last matched.
+	matchedIndex int
+	// matchedCmd is the last matched command.
+	matchedCmd string
+}
+
+// NewReverseSearch returns new reverseSearchState instance.
+func NewReverseSearch(history *History) *reverseSearchState {
+	return &reverseSearchState{
+		history:         history,
+		searchFromIndex: history.selected,
+		matchedIndex:    -1,
+		matchedCmd:      "",
+	}
+}
+
+// reducePrefix reduces the search scope.
+func (rs *reverseSearchState) reducePrefix() {
+	if rs.matchedIndex != -1 {
+		rs.searchFromIndex = rs.matchedIndex - 1
+	}
+	if rs.searchFromIndex < 0 {
+		rs.searchFromIndex = 0
+	}
+}
+
+// update updates current reverse-search state.
+func (rs *reverseSearchState) update(input string) {
+	rs.matchedIndex = rs.history.FindMatch(
+		strings.TrimSpace(input), rs.searchFromIndex,
+	)
+	if rs.matchedIndex != -1 {
+		rs.matchedCmd = rs.history.tmp[rs.matchedIndex]
+	} else {
+		rs.matchedCmd = ""
+	}
+}

--- a/reverse_search_test.go
+++ b/reverse_search_test.go
@@ -1,0 +1,48 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRevSearch(t *testing.T) {
+	history := NewHistory()
+	history.Add("aa")
+	history.Add("ab")
+	history.Add("ac")
+	history.Add("ad")
+	history.Add("ae")
+
+	revSearchState := NewReverseSearch(history)
+
+	assert.Equal(t, len(history.tmp)-1, revSearchState.searchFromIndex)
+	assert.Equal(t, "", revSearchState.matchedCmd)
+	assert.Equal(t, -1, revSearchState.matchedIndex)
+
+	// Update 1.
+	revSearchState.update("a")
+	assert.Equal(t, "ae", revSearchState.matchedCmd)
+	assert.Equal(t, 4, revSearchState.matchedIndex)
+	assert.Equal(t, 5, revSearchState.searchFromIndex)
+
+	// Activate again.
+	revSearchState.reducePrefix()
+	assert.Equal(t, 3, revSearchState.searchFromIndex)
+
+	// Update 2.
+	revSearchState.update("a")
+	assert.Equal(t, "ad", revSearchState.matchedCmd)
+	assert.Equal(t, 3, revSearchState.matchedIndex)
+
+	// Accurate update.
+	revSearchState.update("aa")
+	assert.Equal(t, "aa", revSearchState.matchedCmd)
+	assert.Equal(t, 0, revSearchState.matchedIndex)
+
+	// Activate too many times.
+	for i := 0; i < 10; i++ {
+		revSearchState.reducePrefix()
+	}
+	assert.Equal(t, 0, revSearchState.searchFromIndex)
+}

--- a/shortcut.go
+++ b/shortcut.go
@@ -6,7 +6,7 @@ func dummyExecutor(in string) {}
 func Input(prefix string, completer Completer, opts ...Option) string {
 	pt := New(dummyExecutor, completer)
 	pt.renderer.prefixTextColor = DefaultColor
-	pt.renderer.prefix = prefix
+	pt.prefix = prefix
 
 	for _, opt := range opts {
 		if err := opt(pt); err != nil {
@@ -22,7 +22,7 @@ func Choose(prefix string, choices []string, opts ...Option) string {
 	completer := newChoiceCompleter(choices, FilterHasPrefix)
 	pt := New(dummyExecutor, completer)
 	pt.renderer.prefixTextColor = DefaultColor
-	pt.renderer.prefix = prefix
+	pt.prefix = prefix
 
 	for _, opt := range opts {
 		if err := opt(pt); err != nil {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,70 @@
+import os
+import socket
+import subprocess
+import tempfile
+import uuid
+
+import py
+import pytest
+
+from prompt_app import PromptApp
+
+
+# ######## #
+# Fixtures #
+# ######## #
+def get_tmpdir(request):
+    tmpdir = py.path.local(tempfile.mkdtemp())
+    request.addfinalizer(lambda: tmpdir.remove(rec=1))
+    return str(tmpdir)
+
+
+@pytest.fixture(scope="session")
+def session_tmpdir(request):
+    return get_tmpdir(request)
+
+
+@pytest.fixture(scope="session")
+def go_prompt_app(session_tmpdir):
+    go_prompt_path = os.path.relpath(
+        os.path.join(os.path.dirname(__file__), ".."))
+    prompt_app_path = os.path.join(session_tmpdir, "prompt_app")
+
+    build_env = os.environ.copy()
+    build_env["GO_RPOMPT_BUILD_PATH"] = prompt_app_path
+
+    process = subprocess.run(["make", "build_app"], cwd=go_prompt_path,
+                             env=build_env)
+    assert process.returncode == 0, "Failed to build go prompt app"
+
+    return prompt_app_path
+
+
+@pytest.fixture(scope="session")
+def notification_server(request):
+    socket_uri = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
+    server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_socket.bind(socket_uri)
+    server_socket.listen()
+    request.addfinalizer(server_socket.close)
+    return socket_uri, server_socket
+
+
+@pytest.fixture(scope="function")
+def prompt(request, go_prompt_app, notification_server):
+    params = {}
+    if hasattr(request, "param"):
+        params = request.param
+    if "args" not in params:
+        params["args"] = [""]
+
+    socket_uri, server_socket = notification_server
+    params["server_socket"] = server_socket
+    params["server_socket_uri"] = socket_uri
+    params["args"].append(socket_uri)
+
+    prompt_app = PromptApp()
+    prompt_app.setup(go_prompt_app, params)
+    request.addfinalizer(prompt_app.close)
+
+    return prompt_app

--- a/test/integration/prompt/test_prompt.py
+++ b/test/integration/prompt/test_prompt.py
@@ -1,0 +1,241 @@
+import pytest
+
+
+def test_launch(prompt):
+    assert prompt.get_cursor() == (12, 0)
+    assert prompt.dump_workspace() == "prompt_app>"
+
+
+def test_input_text(prompt):
+    prompt.send_keys("cmd")
+    assert (15, 0) == prompt.get_cursor()
+
+    prompt.send_keys("Enter")
+    assert (12, 2) == prompt.get_cursor()
+
+    prompt.send_keys("русский язык")
+    assert (24, 2) == prompt.get_cursor()
+
+    expected = \
+        """prompt_app> cmd
+cmd: cmd
+prompt_app> русский язык"""
+    assert prompt.dump_workspace() == expected
+
+
+def test_remove_text(prompt):
+    prompt.send_keys("##### e хай hello")
+    prompt.send_keys(["Left"] * 9)
+    prompt.send_keys(["C-h"] * 7)
+    assert prompt.get_cursor() == (13, 0)
+
+    expected = "prompt_app> #хай hello"
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["C-h"] * 2)
+    assert prompt.get_cursor() == (12, 0)
+    expected2 = "prompt_app> хай hello"
+    assert prompt.dump_workspace() == expected2
+
+
+def test_move_over_input(prompt):
+    prompt.send_keys("hello!")
+    prompt.send_keys(["Left"] * 2)
+    assert prompt.get_cursor() == (16, 0)
+
+    prompt.send_keys(["Left"] * 10)
+    assert prompt.get_cursor() == (12, 0)
+
+    prompt.send_keys(["Right"] * 7)
+    assert prompt.get_cursor() == (18, 0)
+
+    prompt.send_keys("слово")
+    prompt.send_keys(["Left"] * 3)
+    assert prompt.get_cursor() == (20, 0)
+
+    expected = "prompt_app> hello!слово"
+    assert prompt.dump_workspace() == expected
+
+
+@pytest.mark.parametrize("prompt", [{"x": "100"}], indirect=True)
+def test_multiline_commands(prompt):
+    prompt.send_keys("строка1\nline2\nline3a")
+    assert prompt.get_cursor() == (6, 2)
+
+    prompt.send_keys(["Left"] * 7)
+    assert prompt.get_cursor() == (5, 1)
+
+    prompt.send_keys(["Left"] * 4)
+    prompt.send_keys(["C-h"] * 2)
+    assert prompt.get_cursor() == (19, 0)
+
+    expected = """prompt_app> строка1ine2
+line3a"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys("абвгдеёжзийклмнопрст")
+    assert prompt.get_cursor() == (39, 0)
+
+    expected = """prompt_app> строка1абвгдеёжзийклмнопрстine2
+line3a"""
+    assert prompt.dump_workspace() == expected
+
+
+def test_enter(prompt):
+    pipeline = [
+        "one line cmd",
+        "Enter",
+        "строка1\nстрока2aa",
+        "Enter",
+        "бессовестно\nмного\nстрокЖ",
+        "Enter"
+    ]
+    for cmd in pipeline:
+        prompt.send_keys(cmd)
+    assert prompt.get_cursor() == (12, 12)
+
+    expected = """prompt_app> one line cmd
+cmd: one line cmd
+prompt_app> строка1
+строка2aa
+cmd: строка1
+строка2aa
+prompt_app> бессовестно
+много
+строкЖ
+cmd: бессовестно
+много
+строкЖ
+prompt_app>"""
+    assert prompt.dump_workspace() == expected
+
+
+# Don't match with completion, using in app.
+HISTORY = [
+    "print(C)",
+    "print(D)",
+    "yuk#",
+    "command",
+    "команда1\nкоманда2\nкоманда3",
+    "a\n\nb",
+    "if a then\n print(x)\nelse\nprint(y)",
+    "interpeter\nдстрокаслово\nfdlqfdsl_fsldgg\nrpewr",
+]
+
+HISTORY_ARG = ";".join(HISTORY)
+
+
+@pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
+def test_move_history(prompt):
+    history_rev = HISTORY.copy()
+    history_rev.reverse()
+
+    # Up.
+    for entry in history_rev:
+        prompt.send_keys("Up")
+        expected = "prompt_app> " + entry
+        assert prompt.dump_workspace() == expected
+
+    # Down.
+    for i in range(1, len(HISTORY)):
+        prompt.send_keys("Down")
+        expected = "prompt_app> " + HISTORY[i]
+        assert prompt.dump_workspace() == expected
+
+    prompt.send_keys("Down")
+    prompt.send_keys("cmd to\nshift cursor")
+
+    # Up.
+    for entry in history_rev:
+        prompt.send_keys("Up")
+        expected = "prompt_app> " + entry
+        assert prompt.dump_workspace() == expected
+
+    # Down.
+    for i in range(1, len(HISTORY)):
+        prompt.send_keys("Down")
+        expected = "prompt_app> " + HISTORY[i]
+        assert prompt.dump_workspace() == expected
+
+
+@pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
+def test_enter_history(prompt):
+    prompt.send_keys(["Up", "Up", "Enter"])
+
+    expected = """prompt_app> if a then
+ print(x)
+else
+print(y)
+cmd: if a then
+ print(x)
+else
+print(y)
+prompt_app>"""
+    assert prompt.dump_workspace() == expected
+
+
+@pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
+def test_reverse_search(prompt):
+    prompt.send_keys(["Some-текст", "C-r"])
+    expected = """(reverse-i-search)`':Some-текст"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["print("])
+    expected = """(reverse-i-search)`print(':if a then
+ print(x)
+else
+print(y)"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["C-r"])
+    expected = """(reverse-i-search)`print(':print(D)"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["C-r"])
+    expected = """(reverse-i-search)`print(':print(C)"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["Left"])
+    expected = """prompt_app> print(C)"""
+    assert prompt.dump_workspace() == expected
+
+    # Check that we are at the past.
+    for i in range(1, len(HISTORY)):
+        prompt.send_keys(["Down"])
+        expected = "prompt_app> " + HISTORY[i]
+        assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["C-r", "not matched with any"])
+    prompt.send_keys(["C-r", "C-r", "C-r"])
+    expected = """(failed reverse-i-search)`not matched with any':"""
+    assert prompt.dump_workspace() == expected
+
+    prompt.send_keys(["Up"])
+    expected = """prompt_app>"""
+    assert prompt.dump_workspace() == expected
+
+
+@pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
+def test_enter_reverse_search(prompt):
+    prompt.send_keys(["C-r", "print(", "Enter"])
+    expected = """prompt_app> if a then
+ print(x)
+else
+print(y)
+cmd: if a then
+ print(x)
+else
+print(y)
+prompt_app>"""
+    kek = prompt.dump_workspace()
+    assert prompt.dump_workspace() == expected
+
+
+@pytest.mark.parametrize("prompt", [{"args": ["if 1\tprint(2)else\tprint(3)"]}], indirect=True)
+def test_tabs(prompt):
+    prompt.send_keys("Hello,\tпривет,\ttabs")
+    assert prompt.get_cursor() == (37, 0)
+    assert prompt.dump_workspace() == "prompt_app> Hello,    привет,    tabs"
+
+    prompt.send_keys("Up")
+    assert prompt.dump_workspace() == "prompt_app> if 1    print(2)else    print(3)"

--- a/test/integration/prompt/test_prompt.py
+++ b/test/integration/prompt/test_prompt.py
@@ -239,3 +239,9 @@ def test_tabs(prompt):
 
     prompt.send_keys("Up")
     assert prompt.dump_workspace() == "prompt_app> if 1    print(2)else    print(3)"
+
+
+def test_console_not_broken(prompt):
+    prompt.send_keys(["exit", "text"])
+    expected = """prompt_app> exittext"""
+    assert prompt.dump_workspace() == expected

--- a/test/prompt_app.py
+++ b/test/prompt_app.py
@@ -1,0 +1,26 @@
+from tmux import Tmux
+
+
+class PromptApp(Tmux):
+    def __init__(self):
+        super().__init__()
+        self.socket_uri = None
+        self.socket = None
+
+    def setup(self, prompt_app, params):
+        server_socket = params["server_socket"]
+        super().setup(prompt_app, params)
+
+        self.socket_uri = params["server_socket_uri"]
+
+        # Wait for the prompt_app to connect.
+        self.socket, _ = server_socket.accept()
+
+    def send_keys(self, keys):
+        if not isinstance(keys, list):
+            keys = [keys]
+
+        for key in keys:
+            super().send_key(key)
+            # Poll rendering socket.
+            self.socket.recv(1)

--- a/test/tmux.py
+++ b/test/tmux.py
@@ -1,0 +1,50 @@
+import subprocess
+import uuid
+
+
+class Tmux:
+    def __init__(self):
+        self.uuid = uuid.uuid4().hex
+
+    def setup(self, executable, params):
+        x = "100"
+        y = "30"
+        args = None
+        if "x" in params:
+            x = params["x"]
+        if "y" in params:
+            y = params["y"]
+        if "args" in params:
+            args = params["args"]
+        cmd = ["tmux", "-L", self.uuid, "new-session", "-d", "-x", x,
+               "-y", y, executable]
+        if args is not None:
+            cmd += args
+
+        subprocess.run(cmd)
+
+    def dump_screen(self):
+        subprocess.run(["tmux", "-L", self.uuid, "capture-pane"])
+        sub = subprocess.run(["tmux", "-L", self.uuid, "show-buffer"],
+                             capture_output=True)
+        subprocess.run(["tmux", "-L", self.uuid, "delete-buffer"])
+
+        return sub.stdout.decode("utf-8")
+
+    def dump_workspace(self):
+        return self.dump_screen().rstrip("\n")
+
+    def get_cursor(self):
+        sub = subprocess.run(["tmux", "-L", self.uuid, "display-message", "-p",
+                              "#{cursor_x} #{cursor_y}"], capture_output=True)
+        output = sub.stdout.decode("utf-8")
+        x, y = list(map(int, output.split(" ")))
+        return x, y
+
+    def send_key(self, key):
+        sub = subprocess.run(["tmux", "-L", self.uuid, "send-keys", key])
+        return sub.returncode
+
+    def close(self):
+        sub = subprocess.run(["tmux", "-L", self.uuid, "kill-server"])
+        assert sub.returncode == 0


### PR DESCRIPTION
This patch brings several changes. 
In General:

Added:
- Support for multi-line commands
- Support for tab characters in commands
- Integration tests

Redesigned:
- Reverse-search feature

Fixed:
- Terminal failure after exiting

Closes #5