### PR TITLE
document: make work with utf8 correct

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -254,9 +254,7 @@ func TestDocument_DisplayCursorPosition(t *testing.T) {
 
 	for _, p := range patterns {
 		ac := p.document.DisplayCursorPosition()
-		if ac != p.expected {
-			t.Errorf("Should be %#v, got %#v", p.expected, ac)
-		}
+		assert.Equal(t, p.expected, ac)
 	}
 }
 
@@ -288,12 +286,10 @@ func TestDocument_GetCharRelativeToCursor(t *testing.T) {
 		},
 	}
 
-	for i, p := range patterns {
+	for _, p := range patterns {
 		ac := p.document.GetCharRelativeToCursor(1)
 		ex, _ := utf8.DecodeRuneInString(p.expected)
-		if ac != ex {
-			t.Errorf("[%d] Should be %s, got %s", i, string(ex), string(ac))
-		}
+		assert.Equal(t, string(ex), string(ac))
 	}
 }
 
@@ -324,11 +320,9 @@ func TestDocument_TextBeforeCursor(t *testing.T) {
 			expected: "Добрый\nде",
 		},
 	}
-	for i, p := range patterns {
+	for _, p := range patterns {
 		ac := p.document.TextBeforeCursor()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %s, got %s", i, p.expected, ac)
-		}
+		assert.Equal(t, p.expected, ac)
 	}
 }
 
@@ -367,11 +361,9 @@ func TestDocument_TextAfterCursor(t *testing.T) {
 		},
 	}
 
-	for i, p := range pattern {
+	for _, p := range pattern {
 		ac := p.document.TextAfterCursor()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
-		}
+		assert.Equal(t, p.expected, ac)
 	}
 }
 
@@ -434,21 +426,15 @@ func TestDocument_GetWordBeforeCursor(t *testing.T) {
 		},
 	}
 
-	for i, p := range pattern {
+	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.GetWordBeforeCursor()
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.GetWordBeforeCursorUntilSeparator("")
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.GetWordBeforeCursorUntilSeparator(p.sep)
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -508,18 +494,12 @@ func TestDocument_GetWordBeforeCursorWithSpace(t *testing.T) {
 	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.GetWordBeforeCursorWithSpace()
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.GetWordBeforeCursorUntilSeparatorIgnoreNextToCursor("")
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.GetWordBeforeCursorUntilSeparatorIgnoreNextToCursor(p.sep)
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -579,18 +559,12 @@ func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.FindStartOfPreviousWord()
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.FindStartOfPreviousWordUntilSeparator("")
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.FindStartOfPreviousWordUntilSeparator(p.sep)
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -650,18 +624,12 @@ func TestDocument_FindStartOfPreviousWordWithSpace(t *testing.T) {
 	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.FindStartOfPreviousWordWithSpace()
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.FindStartOfPreviousWordUntilSeparatorIgnoreNextToCursor("")
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.FindStartOfPreviousWordUntilSeparatorIgnoreNextToCursor(p.sep)
-			if ac != p.expected {
-				t.Errorf("Should be %#v, got %#v", p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -732,21 +700,15 @@ func TestDocument_GetWordAfterCursor(t *testing.T) {
 		},
 	}
 
-	for k, p := range pattern {
+	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.GetWordAfterCursor()
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.GetWordAfterCursorUntilSeparator("")
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.GetWordAfterCursorUntilSeparator(p.sep)
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -825,21 +787,15 @@ func TestDocument_GetWordAfterCursorWithSpace(t *testing.T) {
 		},
 	}
 
-	for k, p := range pattern {
+	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.GetWordAfterCursorWithSpace()
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.GetWordAfterCursorUntilSeparatorIgnoreNextToCursor("")
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.GetWordAfterCursorUntilSeparatorIgnoreNextToCursor(p.sep)
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -919,21 +875,15 @@ func TestDocument_FindEndOfCurrentWord(t *testing.T) {
 		},
 	}
 
-	for k, p := range pattern {
+	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.FindEndOfCurrentWord()
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.FindEndOfCurrentWordUntilSeparator("")
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.FindEndOfCurrentWordUntilSeparator(p.sep)
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -1011,21 +961,15 @@ func TestDocument_FindEndOfCurrentWordWithSpace(t *testing.T) {
 		},
 	}
 
-	for k, p := range pattern {
+	for _, p := range pattern {
 		if p.sep == "" {
 			ac := p.document.FindEndOfCurrentWordWithSpace()
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 			ac = p.document.FindEndOfCurrentWordUntilSeparatorIgnoreNextToCursor("")
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		} else {
 			ac := p.document.FindEndOfCurrentWordUntilSeparatorIgnoreNextToCursor(p.sep)
-			if ac != p.expected {
-				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
-			}
+			assert.Equal(t, p.expected, ac)
 		}
 	}
 }
@@ -1389,19 +1333,11 @@ func TestDocument_TranslateIndexToPosition(t *testing.T) {
 		cursorPosition: len("line 1\n" + "lin"),
 	}
 	row, col := d.TranslateIndexToPosition(len("line 1\nline 2\nlin"))
-	if row != 2 {
-		t.Errorf("Should be %#v, got %#v", 2, row)
-	}
-	if col != 3 {
-		t.Errorf("Should be %#v, got %#v", 3, col)
-	}
+	assert.Equal(t, 2, row)
+	assert.Equal(t, 3, col)
 	row, col = d.TranslateIndexToPosition(0)
-	if row != 0 {
-		t.Errorf("Should be %#v, got %#v", 0, row)
-	}
-	if col != 0 {
-		t.Errorf("Should be %#v, got %#v", 0, col)
-	}
+	assert.Equal(t, 0, row)
+	assert.Equal(t, 0, col)
 }
 
 func TestDocument_TranslateRowColToIndex(t *testing.T) {
@@ -1411,14 +1347,10 @@ func TestDocument_TranslateRowColToIndex(t *testing.T) {
 	}
 	ac := d.TranslateRowColToIndex(2, 3)
 	ex := len("line 1\nline 2\nlin")
-	if ac != ex {
-		t.Errorf("Should be %#v, got %#v", ex, ac)
-	}
+	assert.Equal(t, ex, ac)
 	ac = d.TranslateRowColToIndex(0, 0)
 	ex = 0
-	if ac != ex {
-		t.Errorf("Should be %#v, got %#v", ex, ac)
-	}
+	assert.Equal(t, ex, ac)
 }
 
 func TestDocument_TranslateRowColToCursor(t *testing.T) {
@@ -1448,14 +1380,10 @@ func TestDocument_OnLastLine(t *testing.T) {
 		cursorPosition: len("line 1\nline"),
 	}
 	ac := d.OnLastLine()
-	if ac {
-		t.Errorf("Should be %#v, got %#v", false, ac)
-	}
+	assert.Equal(t, false, ac)
 	d.cursorPosition = len("line 1\nline 2\nline")
 	ac = d.OnLastLine()
-	if !ac {
-		t.Errorf("Should be %#v, got %#v", true, ac)
-	}
+	assert.Equal(t, true, ac)
 }
 
 func TestDocument_GetEndOfLinePosition(t *testing.T) {
@@ -1465,9 +1393,7 @@ func TestDocument_GetEndOfLinePosition(t *testing.T) {
 	}
 	ac := d.GetEndOfLinePosition()
 	ex := len("ne 2")
-	if ac != ex {
-		t.Errorf("Should be %#v, got %#v", ex, ac)
-	}
+	assert.Equal(t, ex, ac)
 }
 
 func Test_getCursorIndex(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/mattn/go-tty v0.0.3
 	github.com/pkg/term v1.2.0-beta.2
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3mdw=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -12,6 +14,11 @@ github.com/mattn/go-tty v0.0.3 h1:5OfyWorkyO7xP52Mq7tB36ajHDG5OHrmBGIS/DtakQI=
 github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
 github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -21,3 +28,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Rewrite some functions in the document.go to
work correct with utf8 characters.

document.go follow next notation:
1) `cursor` means index in the rune array.
2) `index`  means index in the byte array.

Some functions violated this contract.

`findLineStartIndex` must take an index as an argument. (Because, this functions performs subtraction of an argument with some other index).
However, functions `CursorPositionRow`, `CursorPositionCol`, passed the cursor instead of the index.
To fix this, a function that translates the current cursor to an index was written (`getCursorIndex`).
Also,`GetCursorPosition`, `GetCustomCursorPosition` were added for convenience.

`GetCursorLeftPosition` operated with `len(string)` instead of `len([]rune)`. Fixed it.
`GetCursorRightPosition` fixed automatically, because it used another fixed function inside.

`GetCursorUpPosition` and `GetCursorDownPosition` contained similar mistakes.
To fix this `TranslateRowColToIndex` was reworked to `TranslateRowColToCursor`.

The tests have been expanded with `utf8` cases.