### PR TITLE
prompt: fix some keybindings to work with multilines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ vendor/
 # Pytest
 .pytest_cache
 __pycache__
+
+# testing app
+prompt_app
+
+# venv
+venv

--- a/_example/exec-command/main.go
+++ b/_example/exec-command/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/tarantool/go-prompt"
 )
 
 func executor(t string) {

--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/tarantool/go-prompt"
 )
 
 type RequestContext struct {

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/tarantool/go-prompt"
 )
 
 var LivePrefixState struct {

--- a/_example/simple-echo/cjk-cyrillic/main.go
+++ b/_example/simple-echo/cjk-cyrillic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/tarantool/go-prompt"
 )
 
 func executor(in string) {

--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/tarantool/go-prompt"
 )
 
 func completer(in prompt.Document) []prompt.Suggest {

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/completer"
+	prompt "github.com/tarantool/go-prompt"
+	"github.com/tarantool/go-prompt/completer"
 )
 
 var filePathCompleter = completer.FilePathCompleter{

--- a/_tools/vt100_debug/main.go
+++ b/_tools/vt100_debug/main.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main
@@ -6,8 +7,8 @@ import (
 	"fmt"
 	"syscall"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/term"
+	prompt "github.com/tarantool/go-prompt"
+	"github.com/tarantool/go-prompt/internal/term"
 )
 
 func main() {

--- a/buffer.go
+++ b/buffer.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 // Buffer emulates the console buffer.

--- a/completer/file.go
+++ b/completer/file.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/debug"
+	prompt "github.com/tarantool/go-prompt"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 var (

--- a/completion.go
+++ b/completion.go
@@ -3,8 +3,8 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 const (

--- a/document.go
+++ b/document.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
-	"github.com/c-bata/go-prompt/internal/debug"
-	istrings "github.com/c-bata/go-prompt/internal/strings"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/tarantool/go-prompt/internal/bisect"
+	"github.com/tarantool/go-prompt/internal/debug"
+	istrings "github.com/tarantool/go-prompt/internal/strings"
 )
 
 // Document has text displayed in terminal and cursor position.

--- a/document.go
+++ b/document.go
@@ -144,6 +144,36 @@ func (d *Document) FindStartOfPreviousWord() int {
 	return 0
 }
 
+// FindWordStartBackwardCursor finds the start of the word moving backward,
+// returns the associated cursor position.
+// Determines whether a rune is part of a word using `isWordPart`.
+func (d *Document) FindWordStartBackwardCursor(isWordPart func(rune) bool) int {
+	textBeforeCursor := []rune(d.TextBeforeCursor())
+	cursor := len(textBeforeCursor) - 1
+	for cursor >= 0 && !isWordPart(textBeforeCursor[cursor]) {
+		cursor--
+	}
+	for cursor >= 0 && isWordPart(textBeforeCursor[cursor]) {
+		cursor--
+	}
+	return cursor + 1
+}
+
+// FindWordEndForwardCursor finds the end of the word moving forward,
+// returns the cursor position exactly after the end.
+// Determines whether a rune is part of a word using `isWordPart`.
+func (d *Document) FindWordEndForwardCursor(isWordPart func(rune) bool) int {
+	textAfterCursor := []rune(d.TextAfterCursor())
+	cursor := 0
+	for cursor < len(textAfterCursor) && !isWordPart(textAfterCursor[cursor]) {
+		cursor++
+	}
+	for cursor < len(textAfterCursor) && isWordPart(textAfterCursor[cursor]) {
+		cursor++
+	}
+	return d.cursorPosition + cursor
+}
+
 // FindStartOfPreviousWordWithSpace is almost the same as FindStartOfPreviousWord.
 // The only difference is to ignore contiguous spaces.
 func (d *Document) FindStartOfPreviousWordWithSpace() int {

--- a/emacs.go
+++ b/emacs.go
@@ -42,18 +42,12 @@ var emacsKeyBindings = []KeyBind{
 	// Go to the End of the line
 	{
 		Key: ControlE,
-		Fn: func(buf *Buffer) {
-			x := []rune(buf.Document().TextAfterCursor())
-			buf.CursorRight(len(x))
-		},
+		Fn:  GoCmdEnd,
 	},
 	// Go to the beginning of the line
 	{
 		Key: ControlA,
-		Fn: func(buf *Buffer) {
-			x := []rune(buf.Document().TextBeforeCursor())
-			buf.CursorLeft(len(x))
-		},
+		Fn:  GoCmdBeginning,
 	},
 	// Cut the Line after the cursor
 	{
@@ -90,16 +84,12 @@ var emacsKeyBindings = []KeyBind{
 	// Right allow: Forward one character
 	{
 		Key: ControlF,
-		Fn: func(buf *Buffer) {
-			buf.CursorRight(1)
-		},
+		Fn:  GoRightChar,
 	},
 	// Left allow: Backward one character
 	{
 		Key: ControlB,
-		Fn: func(buf *Buffer) {
-			buf.CursorLeft(1)
-		},
+		Fn:  GoLeftChar,
 	},
 	// Cut the Word before the cursor.
 	{

--- a/emacs.go
+++ b/emacs.go
@@ -1,6 +1,6 @@
 package prompt
 
-import "github.com/c-bata/go-prompt/internal/debug"
+import "github.com/tarantool/go-prompt/internal/debug"
 
 /*
 

--- a/emacs.go
+++ b/emacs.go
@@ -39,17 +39,17 @@ Editing
 */
 
 var emacsKeyBindings = []KeyBind{
-	// Go to the End of the line
+	// Go to the End of the command.
 	{
 		Key: ControlE,
 		Fn:  GoCmdEnd,
 	},
-	// Go to the beginning of the line
+	// Go to the beginning of the command.
 	{
 		Key: ControlA,
 		Fn:  GoCmdBeginning,
 	},
-	// Cut the Line after the cursor
+	// Cut the command after the cursor.
 	{
 		Key: ControlK,
 		Fn: func(buf *Buffer) {
@@ -57,7 +57,7 @@ var emacsKeyBindings = []KeyBind{
 			buf.Delete(len(x))
 		},
 	},
-	// Cut/delete the Line before the cursor
+	// Cut the command before the cursor.
 	{
 		Key: ControlU,
 		Fn: func(buf *Buffer) {
@@ -65,7 +65,7 @@ var emacsKeyBindings = []KeyBind{
 			buf.DeleteBeforeCursor(len(x))
 		},
 	},
-	// Delete character under the cursor
+	// Delete character under the cursor.
 	{
 		Key: ControlD,
 		Fn: func(buf *Buffer) {
@@ -74,19 +74,19 @@ var emacsKeyBindings = []KeyBind{
 			}
 		},
 	},
-	// Backspace
+	// Backspace.
 	{
 		Key: ControlH,
 		Fn: func(buf *Buffer) {
 			buf.DeleteBeforeCursor(1)
 		},
 	},
-	// Right allow: Forward one character
+	// Right allow: Forward one character.
 	{
 		Key: ControlF,
 		Fn:  GoRightChar,
 	},
-	// Left allow: Backward one character
+	// Left allow: Backward one character.
 	{
 		Key: ControlB,
 		Fn:  GoLeftChar,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/c-bata/go-prompt
+module github.com/tarantool/go-prompt
 
 go 1.14
 

--- a/input_posix.go
+++ b/input_posix.go
@@ -6,7 +6,7 @@ package prompt
 import (
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/term"
+	"github.com/tarantool/go-prompt/internal/term"
 	"golang.org/x/sys/unix"
 )
 

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
+	"github.com/tarantool/go-prompt/internal/bisect"
 )
 
 func Example() {

--- a/internal/prompt_app/prompt_app.go
+++ b/internal/prompt_app/prompt_app.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/c-bata/go-prompt"
+	"github.com/tarantool/go-prompt"
 )
 
 var (

--- a/internal/prompt_app/prompt_app.go
+++ b/internal/prompt_app/prompt_app.go
@@ -9,6 +9,16 @@ import (
 	"github.com/c-bata/go-prompt"
 )
 
+var (
+	ControlLeftBytes  []byte
+	ControlRightBytes []byte
+)
+
+func init() {
+	ControlLeftBytes = []byte{0x1b, 0x62}
+	ControlRightBytes = []byte{0x1b, 0x66}
+}
+
 // Console describes the console.
 type Console struct {
 	title             string
@@ -81,6 +91,23 @@ func getPromptOptions(console *Console) []prompt.Option {
 
 		prompt.OptionDisableAutoHistory(),
 		prompt.OptionReverseSearch(),
+
+		prompt.OptionAddASCIICodeBind(
+			// Move to one word left.
+			prompt.ASCIICodeBind{
+				ASCIICode: ControlLeftBytes,
+				Fn: func(buf *prompt.Buffer) {
+					prompt.GoLeftWord(buf)
+				},
+			},
+			// Move to one word right.
+			prompt.ASCIICodeBind{
+				ASCIICode: ControlRightBytes,
+				Fn: func(buf *prompt.Buffer) {
+					prompt.GoRightWord(buf)
+				},
+			},
+		),
 	}
 	args := os.Args
 	if len(args) > 1 {

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -3,7 +3,7 @@ package strings_test
 import (
 	"fmt"
 
-	"github.com/c-bata/go-prompt/internal/strings"
+	"github.com/tarantool/go-prompt/internal/strings"
 )
 
 func ExampleIndexNotByte() {

--- a/key_bind.go
+++ b/key_bind.go
@@ -29,12 +29,12 @@ var commonKeyBindings = []KeyBind{
 	// Go to the End of the line
 	{
 		Key: End,
-		Fn:  GoLineEnd,
+		Fn:  GoCmdEnd,
 	},
 	// Go to the beginning of the line
 	{
 		Key: Home,
-		Fn:  GoLineBeginning,
+		Fn:  GoCmdBeginning,
 	},
 	// Delete character under the cursor
 	{

--- a/key_bind_func.go
+++ b/key_bind_func.go
@@ -56,13 +56,26 @@ func GoLeftChar(buf *Buffer) {
 	buf.CursorLeft(1)
 }
 
-// GoRightWord Forward one word.
+// GoRightWord moves the cursor to the end of the next word.
 func GoRightWord(buf *Buffer) {
-	buf.CursorRight(buf.Document().FindEndOfCurrentWordWithSpace())
+	buf.setCursorPosition(buf.Document().FindWordEndForwardCursor(func(r rune) bool {
+		return r != '\n' && r != ' '
+	}))
 }
 
-// GoLeftWord Backward one word.
+// GoLeftWord moves the cursor to the beginning of the previous word.
 func GoLeftWord(buf *Buffer) {
-	buf.CursorLeft(len([]rune(buf.Document().TextBeforeCursor())) - buf.Document().
-		FindStartOfPreviousWordWithSpace())
+	buf.setCursorPosition(buf.Document().FindWordStartBackwardCursor(func(r rune) bool {
+		return r != '\n' && r != ' '
+	}))
+}
+
+// GoCmdBeginning moves the cursor to the beginning of the command.
+func GoCmdBeginning(buf *Buffer) {
+	buf.setCursorPosition(0)
+}
+
+// GoCmdEnd moves the cursor to the end of the command.
+func GoCmdEnd(buf *Buffer) {
+	buf.setCursorPosition(len([]rune(buf.Text())))
 }

--- a/key_bind_func_test.go
+++ b/key_bind_func_test.go
@@ -41,3 +41,155 @@ func TestGoLeftChar(t *testing.T) {
 	GoLeftChar(buf)
 	assert.Equal(t, 7, buf.cursorPosition)
 }
+
+func TestGoCmdBeginning(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		input := "зеленый\nред\nсиний"
+		buf := NewBuffer()
+		buf.InsertText(input, false, true)
+
+		GoCmdBeginning(buf)
+		assert.Equal(t, 0, buf.cursorPosition)
+
+		buf.cursorPosition = 2
+		GoCmdBeginning(buf)
+		assert.Equal(t, 0, buf.cursorPosition)
+	})
+
+	t.Run("empty buffer", func(t *testing.T) {
+		buf := NewBuffer()
+		GoCmdBeginning(buf)
+		assert.Equal(t, 0, buf.cursorPosition)
+	})
+}
+
+func TestGoCmdEnd(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		input := "зеленый\nред\nсиний"
+		buf := NewBuffer()
+		buf.InsertText(input, false, true)
+
+		GoCmdEnd(buf)
+		assert.Equal(t, 17, buf.cursorPosition)
+
+		buf.cursorPosition = 0
+		GoCmdEnd(buf)
+		assert.Equal(t, 17, buf.cursorPosition)
+	})
+
+	t.Run("empty buffer", func(t *testing.T) {
+		buf := NewBuffer()
+		GoCmdBeginning(buf)
+		assert.Equal(t, 0, buf.cursorPosition)
+	})
+}
+
+func TestGoLeftWord(t *testing.T) {
+	cases := []struct {
+		description    string
+		input          string
+		cursor         int
+		expectedCursor int
+	}{
+		{
+			"wo[r]d  -> [w]ord",
+			"word",
+			2,
+			0,
+		},
+		{
+			" word[] -> [w]ord ",
+			" word  ",
+			5,
+			1,
+		},
+		{
+			"строка 1\n[с]трока2\nстрока3 -> строка [1]\nстрока2\nстрока3",
+			"строка 1\nстрока2\nстрока3 ",
+			9,
+			7,
+		},
+		{
+			"слово\nслово2\n[с]лово3 -> слово\n[с]лово2\nслово3",
+			"слово\nслово2\nслово3",
+			13,
+			6,
+		},
+		{
+			"some long []  line -> some [l]ong    line",
+			"some long    line",
+			10,
+			5,
+		},
+		{
+			"[] -> []",
+			"",
+			0,
+			0,
+		},
+		{
+			"a\n\n\n\n\n\n[b]a -> [a]\n\n\n\n\n\nba",
+			"a\n\n\n\n\n\nba",
+			7,
+			0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			buf := NewBuffer()
+			buf.InsertText(tc.input, false, true)
+			buf.setCursorPosition(tc.cursor)
+			GoLeftWord(buf)
+			assert.Equal(t, tc.expectedCursor, buf.cursorPosition)
+		})
+	}
+}
+
+func TestGoRightWord(t *testing.T) {
+	cases := []struct {
+		description    string
+		input          string
+		cursor         int
+		expectedCursor int
+	}{
+		{
+			"wo[r]d -> word[]",
+			"word",
+			2,
+			4,
+		},
+		{
+			" []  word ->    word[]",
+			"    word",
+			1,
+			8,
+		},
+		{
+			"строка1\n[]строка2\nстрока3 -> строка1\n строка2[\n]строка3",
+			"строка1\n строка2\nстрока3",
+			8,
+			16,
+		},
+		{
+			"[] -> []",
+			"",
+			0,
+			0,
+		},
+		{
+			"[\n]\n\n\nслово->\n\n\n\nслово[]",
+			"\n\n\n\nслово",
+			0,
+			9,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			buf := NewBuffer()
+			buf.InsertText(tc.input, false, true)
+			buf.setCursorPosition(tc.cursor)
+			GoRightWord(buf)
+			assert.Equal(t, tc.expectedCursor, buf.cursorPosition)
+		})
+	}
+}

--- a/prompt.go
+++ b/prompt.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 // Executor is called when user input something text.

--- a/prompt.go
+++ b/prompt.go
@@ -236,7 +236,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 				p.buf = newBuf
 			}
 		}
-	case Left, Right:
+	case Left, Right, ControlB, ControlF:
 		if p.inReverseSearchMode() {
 			p.disableReverseSearch()
 		}

--- a/render.go
+++ b/render.go
@@ -3,8 +3,8 @@ package prompt
 import (
 	"runtime"
 
-	"github.com/c-bata/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 const (

--- a/signal_posix.go
+++ b/signal_posix.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package prompt
@@ -7,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/tarantool/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {

--- a/test/integration/prompt/pipelines/completion_revsearch.yml
+++ b/test/integration/prompt/pipelines/completion_revsearch.yml
@@ -1,0 +1,71 @@
+- cmd: [a]
+  pane: |
+    prompt_app> a
+                  abc
+                  aad
+                  aba
+                  aart
+                  apple
+- cmd: [b]
+  pane: |
+    prompt_app> ab
+                   abc
+                   aba
+
+- cmd: [Tab, Tab]
+  pane: |
+    prompt_app> aba
+                   abc
+                   aba
+
+- cmd: [Enter]
+  pane: |
+    prompt_app> aba
+    cmd: aba
+    prompt_app>
+
+- cmd: [C-r, q]
+  pane: |
+    prompt_app> aba
+    cmd: aba
+    (failed reverse-i-search)`q':
+
+- cmd: [Left, C-l]
+  pane: |
+    prompt_app>
+
+- cmd: [C-r, a]
+  pane: |
+    (reverse-i-search)`a':aba
+
+- cmd: [Enter]
+  pane: |
+    prompt_app> aba
+    cmd: aba
+    prompt_app>
+
+- cmd: ["if some then\nprint(один)", Enter]
+
+- cmd: ["if some then\nprint(три)\nelse\nprint(четыре)", Enter, C-l]
+  pane: |
+    prompt_app> 
+
+- cmd: [C-r, pri]
+  pane: |
+    (reverse-i-search)`pri':if some then
+    print(три)
+    else
+    print(четыре)
+
+- cmd: [C-r]
+  pane: |
+    (reverse-i-search)`pri':if some then
+    print(один)
+
+- cmd: [Enter]
+  pane: |
+    prompt_app> if some then
+    print(один)
+    cmd: if some then
+    print(один)
+    prompt_app>

--- a/test/integration/prompt/pipelines/erase_manipulations.yml
+++ b/test/integration/prompt/pipelines/erase_manipulations.yml
@@ -1,0 +1,50 @@
+- cmd: |
+    hello
+     world
+    а также
+        мир!
+  pane: |
+    prompt_app> hello
+     world
+    а также
+        мир!
+
+- cmd: [C-w]
+  pane: |
+    prompt_app> hello
+     world
+    а также
+  cursor: [4, 3]
+
+- cmd: [M-b, M-b, C-k]
+  pane: |
+    prompt_app> hello
+     world
+    
+- cmd: |
+    дополнительные
+    много
+    строчек, да!
+
+- cmd: [M-b, C-u]
+  pane: |
+    prompt_app> да!
+
+- cmd: [C-d, C-d]
+  pane: |
+    prompt_app> !
+
+- cmd: |
+    снова
+    много строчек
+    а б в г д е
+
+- cmd: [C-w, C-w, C-w, C-w, C-w]
+  pane: |
+    prompt_app> снова
+    много строчек
+    а !
+
+- cmd: [C-k, C-w, C-w, C-w, C-w, C-w, C-w, C-w, C-w] # too many
+  pane: |
+    prompt_app>

--- a/test/integration/prompt/test_prompt.py
+++ b/test/integration/prompt/test_prompt.py
@@ -1,16 +1,45 @@
 import pytest
 
+DEFAULT_KEYS = {
+    "Left": "Left",
+    "Right": "Right",
+    "Erase": "BSpace",
+    "Enter": "Enter",
+    "Up": "Up",
+    "Down": "Down",
+    "C-r": "C-r",
+    "Home": "Home",
+    "End": "End",
+    "M-b": "M-b",
+    "M-f": "M-f",
+}
+
+EMACS_KEYS = {
+    "Left": "C-b",
+    "Right": "C-f",
+    "Erase": "C-h",
+    "Enter": "C-m",
+    "Up": "C-p",
+    "Down": "C-n",
+    "C-r": "C-r",
+    "Home": "c-a",
+    "End": "c-e",
+    "M-b": "M-b",
+    "M-f": "M-f",
+}
+
 
 def test_launch(prompt):
     assert prompt.get_cursor() == (12, 0)
     assert prompt.dump_workspace() == "prompt_app>"
 
 
-def test_input_text(prompt):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_input_text(prompt, keys):
     prompt.send_keys("cmd")
     assert (15, 0) == prompt.get_cursor()
 
-    prompt.send_keys("Enter")
+    prompt.send_keys(keys["Enter"])
     assert (12, 2) == prompt.get_cursor()
 
     prompt.send_keys("русский язык")
@@ -23,57 +52,53 @@ prompt_app> русский язык"""
     assert prompt.dump_workspace() == expected
 
 
-@pytest.mark.parametrize("erase_key", ["C-h", "BSpace"])
-def test_remove_text(prompt, erase_key):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_remove_text(prompt, keys):
     prompt.send_keys("##### e хай hello")
-    prompt.send_keys(["Left"] * 9)
-    prompt.send_keys([erase_key] * 7)
+    prompt.send_keys([keys["Left"]] * 9)
+    prompt.send_keys([keys["Erase"]] * 7)
     assert prompt.get_cursor() == (13, 0)
 
     expected = "prompt_app> #хай hello"
     assert prompt.dump_workspace() == expected
 
-    prompt.send_keys([erase_key] * 2)
+    prompt.send_keys([keys["Erase"]] * 2)
     assert prompt.get_cursor() == (12, 0)
     expected2 = "prompt_app> хай hello"
     assert prompt.dump_workspace() == expected2
 
 
-@pytest.mark.parametrize("left_key, right_key", [
-    pytest.param("Left", "Right"),
-    pytest.param("C-b", "C-f")  # emacs
-])
-def test_move_over_input(prompt, left_key, right_key):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_move_over_input(prompt, keys):
     prompt.send_keys("hello!")
-    prompt.send_keys([left_key] * 2)
+    prompt.send_keys([keys["Left"]] * 2)
     assert prompt.get_cursor() == (16, 0)
 
-    prompt.send_keys([left_key] * 10)
+    prompt.send_keys([keys["Left"]] * 10)
     assert prompt.get_cursor() == (12, 0)
 
-    prompt.send_keys([right_key] * 7)
+    prompt.send_keys([keys["Right"]] * 7)
     assert prompt.get_cursor() == (18, 0)
 
     prompt.send_keys("слово")
-    prompt.send_keys([left_key] * 3)
+    prompt.send_keys([keys["Left"]] * 3)
     assert prompt.get_cursor() == (20, 0)
 
     expected = "prompt_app> hello!слово"
     assert prompt.dump_workspace() == expected
 
 
-@pytest.mark.parametrize("left_key", ["Left", "C-b"])
-@pytest.mark.parametrize("erase_key", ["BSpace", "C-h"])
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize("prompt", [{"x": "100"}], indirect=True)
-def test_multiline_commands(prompt, left_key, erase_key):
+def test_multiline_commands(prompt, keys):
     prompt.send_keys("строка1\nline2\nline3a")
     assert prompt.get_cursor() == (6, 2)
 
-    prompt.send_keys([left_key] * 7)
+    prompt.send_keys([keys["Left"]] * 7)
     assert prompt.get_cursor() == (5, 1)
 
-    prompt.send_keys([left_key] * 4)
-    prompt.send_keys([erase_key] * 2)
+    prompt.send_keys([keys["Left"]] * 4)
+    prompt.send_keys([keys["Erase"]] * 2)
     assert prompt.get_cursor() == (19, 0)
 
     expected = """prompt_app> строка1ine2
@@ -88,14 +113,15 @@ line3a"""
     assert prompt.dump_workspace() == expected
 
 
-def test_enter(prompt):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_enter(prompt, keys):
     pipeline = [
         "one line cmd",
-        "Enter",
+        keys["Enter"],
         "строка1\nстрока2aa",
-        "Enter",
+        keys["Enter"],
         "бессовестно\nмного\nстрокЖ",
-        "Enter"
+        keys["Enter"]
     ]
     for cmd in pipeline:
         prompt.send_keys(cmd)
@@ -132,20 +158,21 @@ HISTORY = [
 HISTORY_ARG = ";".join(HISTORY)
 
 
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
-def test_move_history(prompt):
+def test_move_history(prompt, keys):
     history_rev = HISTORY.copy()
     history_rev.reverse()
 
     # Up.
     for entry in history_rev:
-        prompt.send_keys("Up")
+        prompt.send_keys(keys["Up"])
         expected = "prompt_app> " + entry
         assert prompt.dump_workspace() == expected
 
     # Down.
     for i in range(1, len(HISTORY)):
-        prompt.send_keys("Down")
+        prompt.send_keys(keys["Down"])
         expected = "prompt_app> " + HISTORY[i]
         assert prompt.dump_workspace() == expected
 
@@ -154,20 +181,21 @@ def test_move_history(prompt):
 
     # Up.
     for entry in history_rev:
-        prompt.send_keys("Up")
+        prompt.send_keys(keys["Up"])
         expected = "prompt_app> " + entry
         assert prompt.dump_workspace() == expected
 
     # Down.
     for i in range(1, len(HISTORY)):
-        prompt.send_keys("Down")
+        prompt.send_keys(keys["Down"])
         expected = "prompt_app> " + HISTORY[i]
         assert prompt.dump_workspace() == expected
 
 
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
-def test_enter_history(prompt):
-    prompt.send_keys(["Up", "Up", "Enter"])
+def test_enter_history(prompt, keys):
+    prompt.send_keys([keys["Up"], keys["Up"], keys["Enter"]])
 
     expected = """prompt_app> if a then
  print(x)
@@ -181,9 +209,10 @@ prompt_app>"""
     assert prompt.dump_workspace() == expected
 
 
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
-def test_reverse_search(prompt):
-    prompt.send_keys(["Some-текст", "C-r"])
+def test_reverse_search(prompt, keys):
+    prompt.send_keys(["Some-текст", keys["C-r"]])
     expected = """(reverse-i-search)`':Some-текст"""
     assert prompt.dump_workspace() == expected
 
@@ -194,37 +223,38 @@ else
 print(y)"""
     assert prompt.dump_workspace() == expected
 
-    prompt.send_keys(["C-r"])
+    prompt.send_keys(keys["C-r"])
     expected = """(reverse-i-search)`print(':print(D)"""
     assert prompt.dump_workspace() == expected
 
-    prompt.send_keys(["C-r"])
+    prompt.send_keys(keys["C-r"])
     expected = """(reverse-i-search)`print(':print(C)"""
     assert prompt.dump_workspace() == expected
 
-    prompt.send_keys(["Left"])
+    prompt.send_keys(keys["Left"])
     expected = """prompt_app> print(C)"""
     assert prompt.dump_workspace() == expected
 
     # Check that we are at the past.
     for i in range(1, len(HISTORY)):
-        prompt.send_keys(["Down"])
+        prompt.send_keys(keys["Down"])
         expected = "prompt_app> " + HISTORY[i]
         assert prompt.dump_workspace() == expected
 
-    prompt.send_keys(["C-r", "not matched with any"])
-    prompt.send_keys(["C-r", "C-r", "C-r"])
+    prompt.send_keys([keys["C-r"], "not matched with any"])
+    prompt.send_keys([keys["C-r"], keys["C-r"], keys["C-r"]])
     expected = """(failed reverse-i-search)`not matched with any':"""
     assert prompt.dump_workspace() == expected
 
-    prompt.send_keys(["Up"])
+    prompt.send_keys(keys["Up"])
     expected = """prompt_app>"""
     assert prompt.dump_workspace() == expected
 
 
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize("prompt", [{"args": [HISTORY_ARG]}], indirect=True)
-def test_enter_reverse_search(prompt):
-    prompt.send_keys(["C-r", "print(", "Enter"])
+def test_enter_reverse_search(prompt, keys):
+    prompt.send_keys(["C-r", "print(", keys["Enter"]])
     expected = """prompt_app> if a then
  print(x)
 else
@@ -237,17 +267,18 @@ prompt_app>"""
     assert prompt.dump_workspace() == expected
 
 
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
 @pytest.mark.parametrize(
     "prompt",
     [{"args": ["if 1\tprint(2)else\tprint(3)"]}],
     indirect=True
 )
-def test_tabs(prompt):
+def test_tabs(prompt, keys):
     prompt.send_keys("Hello,\tпривет,\ttabs")
     assert prompt.get_cursor() == (37, 0)
     assert prompt.dump_workspace() == "prompt_app> Hello,    привет,    tabs"
 
-    prompt.send_keys("Up")
+    prompt.send_keys(keys["Up"])
     expected = "prompt_app> if 1    print(2)else    print(3)"
     assert prompt.dump_workspace() == expected
 
@@ -258,27 +289,24 @@ def test_console_not_broken(prompt):
     assert prompt.dump_workspace() == expected
 
 
-@pytest.mark.parametrize("home_key, end_key", [
-    pytest.param("Home", "End"),
-    pytest.param("C-a", "C-e"),  # emacs
-])
-def test_home_end_keys(prompt, home_key, end_key):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_home_end_keys(prompt, keys):
     cmd = """здравствуй,
 nebo
 в облаках"""
     prompt.send_keys(cmd)
     assert prompt.get_cursor() == (9, 2)
 
-    prompt.send_keys(home_key)
+    prompt.send_keys(keys["Home"])
     assert prompt.get_cursor() == (12, 0)
 
-    prompt.send_keys(["Right"] * 7 + [home_key])
+    prompt.send_keys(["Right"] * 7 + [keys["Home"]])
     assert prompt.get_cursor() == (12, 0)
 
-    prompt.send_keys(end_key)
+    prompt.send_keys(keys["End"])
     assert prompt.get_cursor() == (9, 2)
 
-    prompt.send_keys(["Left"] * 9 + [end_key])
+    prompt.send_keys(["Left"] * 9 + [keys["End"]])
     assert prompt.get_cursor() == (9, 2)
 
     prompt.send_keys(["\n-текст"])
@@ -289,10 +317,8 @@ nebo
     assert prompt.dump_workspace() == expected
 
 
-@pytest.mark.parametrize("word_left_key, word_right_key", [
-    pytest.param("M-b", "M-f")
-])
-def test_go_left_right_word(prompt, word_left_key, word_right_key):
+@pytest.mark.parametrize("keys", [DEFAULT_KEYS, EMACS_KEYS])
+def test_go_left_right_word(prompt, keys):
     cmd = """a b c d
 слово1 слово2 слово3   слово4
 d
@@ -301,11 +327,11 @@ d
 б"""
     # Go left from the end.
     cmds = [
-        [cmd, word_left_key],
-        word_left_key,
-        word_left_key,
-        ["Left", "Left", word_left_key],
-        [word_left_key] * 6
+        [cmd, keys["M-b"]],
+        keys["M-b"],
+        keys["M-b"],
+        ["Left", "Left", keys["M-b"]],
+        [keys["M-b"]] * 6
     ]
     cursors = [
         (0, 5),
@@ -320,11 +346,11 @@ d
 
     # Go right from the beginning.
     cmds = [
-        word_right_key,
-        word_right_key,
-        [word_right_key] * 5,
-        ["Right", "Right", word_right_key],
-        [word_right_key] * 2
+        keys["M-f"],
+        keys["M-f"],
+        [keys["M-f"]] * 5,
+        ["Right", "Right", keys["M-f"]],
+        [keys["M-f"]] * 2
     ]
     cursors = [
         (13, 0),

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ pytest==6.2.5
 flake8==3.8.1
 flake8-unused-arguments==0.0.6
 flake8-isort==4.0.0
+pyyaml==6.0.1


### PR DESCRIPTION
- The behavior of the `Home`/`End` has been changed:
now, the cursor moves to the beginning/end of the entire command
(instead of the line) when these keys are pressed.

- The behavior of the `alt-b`/`alt-f` has been changed:
now, the cursor moves one word backward in multiline commands, and
the word delimeter characters are `\n` and ` `.

- The associated emacs keybindings have been changed:
now `ctrl-b`/`ctrl-f` allow to move over the entire multiline command.
`ctrl-a`/`ctrl-e` same as `Home`/`End`.

- Added integration tests for emacs keyset.

Closes #6