### PR TITLE
go-prompt: fix update completion data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 env:
   GO_VERSION: 1.14
-  PYTHON_VERSION: '3.x'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   tests:

--- a/completion.go
+++ b/completion.go
@@ -66,6 +66,10 @@ func (c *CompletionManager) Reset() {
 // Update to update the suggestions.
 func (c *CompletionManager) Update(in Document) {
 	c.tmp = c.completer(in)
+	if c.selected >= len(c.tmp) {
+		c.selected = -1
+		c.verticalScroll = 0
+	}
 }
 
 // Previous to select the previous suggestion item.


### PR DESCRIPTION
The issue that in `GetSelectedSuggestion()` there is no checks that index in valid range. So here we are resetting `selected` index, if length of new array is less, than it was.

Part of https://github.com/tarantool/tt/issues/944